### PR TITLE
peer dependency of Browserify > 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "statham": "^1.0.0"
   },
   "peerDependencies": {
-    "browserify": "x.x.x"
+    "browserify": "^4.1.0"
   }
 }


### PR DESCRIPTION
To solve issues with older versions of browserify
